### PR TITLE
bench_test: Prefer ResetTimer over stop/start

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -7,9 +7,8 @@ import (
 const n = 1000
 
 func BenchmarkNew(b *testing.B) {
-	b.StopTimer()
 	a := make([]int64, n)
-	b.StartTimer()
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_ = New(a...)
 	}
@@ -17,6 +16,7 @@ func BenchmarkNew(b *testing.B) {
 
 func BenchmarkAppend(b *testing.B) {
 	l := new(List)
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		for j := 0; j < n; j++ {
 			l.Append(int64(j))
@@ -25,10 +25,9 @@ func BenchmarkAppend(b *testing.B) {
 }
 
 func BenchmarkSum(b *testing.B) {
-	b.StopTimer()
 	a := make([]int64, n)
 	l := New(a...)
-	b.StartTimer()
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		for j := 0; j < n; j++ {
 			_ = l.Sum(j)
@@ -37,10 +36,9 @@ func BenchmarkSum(b *testing.B) {
 }
 
 func BenchmarkGet(b *testing.B) {
-	b.StopTimer()
 	a := make([]int64, n)
 	l := New(a...)
-	b.StartTimer()
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		for j := 0; j < n; j++ {
 			_ = l.Get(j)
@@ -49,10 +47,9 @@ func BenchmarkGet(b *testing.B) {
 }
 
 func BenchmarkSet(b *testing.B) {
-	b.StopTimer()
 	a := make([]int64, n)
 	l := New(a...)
-	b.StartTimer()
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		for j := 0; j < n; j++ {
 			l.Set(j, int64(j))
@@ -61,10 +58,9 @@ func BenchmarkSet(b *testing.B) {
 }
 
 func BenchmarkAdd(b *testing.B) {
-	b.StopTimer()
 	a := make([]int64, n)
 	l := New(a...)
-	b.StartTimer()
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		for j := 0; j < n; j++ {
 			l.Add(j, int64(j))


### PR DESCRIPTION
I believe is more conventional than pausing the existing timer after test setup.

https://golang.org/pkg/testing/#hdr-Benchmarks